### PR TITLE
Windows fix: do not fail on `git clone` if repo already exists

### DIFF
--- a/external/ios/build_boost.sh
+++ b/external/ios/build_boost.sh
@@ -13,8 +13,25 @@ BOOST_LIBS="random regex graph random chrono thread filesystem system date_time 
 echo "============================ Boost ============================"
 
 echo "Cloning Apple-Boost-BuildScript from - $BOOST_URL"
-git clone -b build $BOOST_URL $BOOST_DIR_PATH
-cd $BOOST_DIR_PATH
+
+# Check if the directory already exists.
+if [ -d "$BOOST_DIR_PATH" ]; then
+    echo "Boost directory already exists."
+else
+    echo "Cloning Boost from $BOOST_URL"
+    git clone -b build $BOOST_URL $BOOST_DIR_PATH
+fi
+
+# Verify if the repository was cloned successfully.
+if [ -d "$BOOST_DIR_PATH/.git" ]; then
+    echo "Boost repository cloned successfully."
+	cd $BOOST_DIR_PATH
+    git checkout build
+else
+    echo "Failed to clone Boost repository. Exiting."
+    exit 1
+fi
+
 ./boost.sh -ios \
 	--min-ios-version ${MIN_IOS_VERSION} \
 	--boost-libs "${BOOST_LIBS}" \

--- a/external/ios/build_openssl.sh
+++ b/external/ios/build_openssl.sh
@@ -11,7 +11,24 @@ echo "============================ OpenSSL ============================"
 
 echo "Cloning Open SSL from - $OPEN_SSL_URL"
 git clone $OPEN_SSL_URL $OPEN_SSL_DIR_PATH
-cd $OPEN_SSL_DIR_PATH
+
+# Check if the directory already exists.
+if [ -d "$OPEN_SSL_DIR_PATH" ]; then
+    echo "OpenSSL directory already exists."
+else
+    echo "Cloning OpenSSL from $OPEN_SSL_URL"
+	git clone $OPEN_SSL_URL $OPEN_SSL_DIR_PATH
+fi
+
+# Verify if the repository was cloned successfully.
+if [ -d "$OPEN_SSL_DIR_PATH/.git" ]; then
+    echo "OpenSSL repository cloned successfully."
+	cd $OPEN_SSL_DIR_PATH
+else
+    echo "Failed to clone OpenSSL repository. Exiting."
+    exit 1
+fi
+
 ./build-libssl.sh --version=1.1.1q --targets="ios-cross-arm64" --deprecated
 
 mv ${OPEN_SSL_DIR_PATH}/include/* $EXTERNAL_IOS_INCLUDE_DIR

--- a/external/ios/build_sodium.sh
+++ b/external/ios/build_sodium.sh
@@ -10,9 +10,25 @@ SODIUM_URL="https://github.com/jedisct1/libsodium.git"
 echo "============================ SODIUM ============================"
 
 echo "Cloning SODIUM from - $SODIUM_URL"
-git clone $SODIUM_URL $SODIUM_PATH
-cd $SODIUM_PATH
-git checkout 443617d7507498f7477703f0b51cb596d4539262
+
+# Check if the directory already exists.
+if [ -d "$SODIUM_PATH" ]; then
+    echo "Sodium directory already exists."
+else
+    echo "Cloning Sodium from $SODIUM_URL"
+	git clone $SODIUM_URL $SODIUM_PATH
+fi
+
+# Verify if the repository was cloned successfully.
+if [ -d "$SODIUM_PATH/.git" ]; then
+    echo "Sodium repository cloned successfully."
+	cd $SODIUM_PATH
+	git checkout 443617d7507498f7477703f0b51cb596d4539262
+else
+    echo "Failed to clone Sodium repository. Exiting."
+    exit 1
+fi
+
 ./dist-build/apple-xcframework.sh
 
 mv ${SODIUM_PATH}/libsodium-apple/ios/include/* $EXTERNAL_IOS_INCLUDE_DIR

--- a/external/ios/build_unbound.sh
+++ b/external/ios/build_unbound.sh
@@ -7,13 +7,30 @@ set -e
 UNBOUND_VERSION=release-1.16.2
 UNBOUND_HASH="cbed768b8ff9bfcf11089a5f1699b7e5707f1ea5"
 UNBOUND_URL="https://www.nlnetlabs.nl/downloads/unbound/unbound-${UNBOUND_VERSION}.tar.gz"
+UNBOUND_GIT_URL="https://github.com/NLnetLabs/unbound.git"
 UNBOUND_DIR_PATH="${EXTERNAL_IOS_SOURCE_DIR}/unbound-1.16.2"
 
 echo "============================ Unbound ============================"
 rm -rf ${UNBOUND_DIR_PATH}
-git clone https://github.com/NLnetLabs/unbound.git -b ${UNBOUND_VERSION} ${UNBOUND_DIR_PATH}
-cd $UNBOUND_DIR_PATH
-test `git rev-parse HEAD` = ${UNBOUND_HASH} || exit 1
+
+# Check if the directory already exists.
+if [ -d "$UNBOUND_DIR_PATH" ]; then
+    echo "Unbound directory already exists."
+else
+    echo "Cloning Unbound from $Unbound_URL"
+	git clone $UNBOUND_GIT_URL -b ${UNBOUND_VERSION} ${UNBOUND_DIR_PATH}
+fi
+
+# Verify if the repository was cloned successfully.
+if [ -d "$UNBOUND_DIR_PATH/.git" ]; then
+    echo "Unbound repository cloned successfully."
+	cd $UNBOUND_DIR_PATH
+	git checkout $UNBOUND_VERSION # Or UNBOUND_HASH.
+	test `git rev-parse HEAD` = ${UNBOUND_HASH} || exit 1
+else
+    echo "Failed to clone Unbound repository. Exiting."
+    exit 1
+fi
 
 export IOS_SDK=iPhone
 export IOS_CPU=arm64

--- a/external/ios/build_zmq.sh
+++ b/external/ios/build_zmq.sh
@@ -10,9 +10,25 @@ ZMQ_URL="https://github.com/zeromq/libzmq.git"
 echo "============================ ZMQ ============================"
 
 echo "Cloning ZMQ from - $ZMQ_URL"
-git clone $ZMQ_URL $ZMQ_PATH
-cd $ZMQ_PATH
-mkdir cmake-build
+
+# Check if the directory already exists.
+if [ -d "$ZMQ_PATH" ]; then
+    echo "ZeroMQ directory already exists."
+else
+    echo "Cloning ZeroMQ from $ZeroMQ_URL"
+	git clone $ZMQ_URL $ZMQ_PATH
+fi
+
+# Verify if the repository was cloned successfully.
+if [ -d "$ZMQ_PATH/.git" ]; then
+    echo "ZeroMQ repository cloned successfully."
+	cd $ZMQ_PATH
+else
+    echo "Failed to clone ZeroMQ repository. Exiting."
+    exit 1
+fi
+
+mkdir -p cmake-build
 cd cmake-build
 cmake ..
 make


### PR DESCRIPTION
build_single.sh will fail on Windows (WSL2) due to `git clone` if we already did a `git submodule update --init --recursive`.  These script changes attempt to check whether the folder already exists, and if it does, attempts to checkout the appropriate branch/tag/commit.