### PR TITLE
iOS build: do not fail due to `mv: Directory not empty`

### DIFF
--- a/external/ios/build_boost.sh
+++ b/external/ios/build_boost.sh
@@ -38,5 +38,5 @@ fi
 	--boost-version ${BOOST_VERSION} \
 	--no-framework
 
-mv ${BOOST_DIR_PATH}/build/boost/${BOOST_VERSION}/ios/release/prefix/include/*  $EXTERNAL_IOS_INCLUDE_DIR
-mv ${BOOST_DIR_PATH}/build/boost/${BOOST_VERSION}/ios/release/prefix/lib/*  $EXTERNAL_IOS_LIB_DIR
+mv -f -n ${BOOST_DIR_PATH}/build/boost/${BOOST_VERSION}/ios/release/prefix/include/*  $EXTERNAL_IOS_INCLUDE_DIR
+mv -f -n ${BOOST_DIR_PATH}/build/boost/${BOOST_VERSION}/ios/release/prefix/lib/*  $EXTERNAL_IOS_LIB_DIR

--- a/external/ios/build_openssl.sh
+++ b/external/ios/build_openssl.sh
@@ -30,6 +30,6 @@ fi
 
 ./build-libssl.sh --version=1.1.1q --targets="ios-cross-arm64" --deprecated
 
-mv ${OPEN_SSL_DIR_PATH}/include/* $EXTERNAL_IOS_INCLUDE_DIR
+mv -f -n ${OPEN_SSL_DIR_PATH}/include/* $EXTERNAL_IOS_INCLUDE_DIR
 mv ${OPEN_SSL_DIR_PATH}/lib/libcrypto-iOS.a ${EXTERNAL_IOS_LIB_DIR}/libcrypto.a
 mv ${OPEN_SSL_DIR_PATH}/lib/libssl-iOS.a ${EXTERNAL_IOS_LIB_DIR}/libssl.a

--- a/external/ios/build_sodium.sh
+++ b/external/ios/build_sodium.sh
@@ -31,5 +31,5 @@ fi
 
 ./dist-build/apple-xcframework.sh
 
-mv ${SODIUM_PATH}/libsodium-apple/ios/include/* $EXTERNAL_IOS_INCLUDE_DIR
-mv ${SODIUM_PATH}/libsodium-apple/ios/lib/* $EXTERNAL_IOS_LIB_DIR
+mv -f -n ${SODIUM_PATH}/libsodium-apple/ios/include/* $EXTERNAL_IOS_INCLUDE_DIR
+mv -f -n ${SODIUM_PATH}/libsodium-apple/ios/lib/* $EXTERNAL_IOS_LIB_DIR


### PR DESCRIPTION
This only applies to subsequent/"dirty" builds, but is helpful in cases where one of several dependencies fails and you don't want to have to rebuild them all.