### PR TITLE
add action to check for invalid dependencies

### DIFF
--- a/.github/workflows/dependencies_matches.yaml
+++ b/.github/workflows/dependencies_matches.yaml
@@ -57,9 +57,6 @@ jobs:
       - name: prepare
         run: |
           set -x
-          pushd external/polyseed
-            echo "EXTERNAL_POLYSEED=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          popd
           pushd ${{ matrix.coin }}/contrib/depends
             make download # sorry, this is the easiest way
             mkdir sources/polyseed
@@ -69,8 +66,8 @@ jobs:
           popd
       - name: diff
         run: |
-          OUTPUT=$(diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed | grep -v .git)
-          if [[ ! "x$OUTPUT" == "x" ]];
+          OUTPUT=$(diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed | grep -v .git | wc -l)
+          if [[ ! "x$OUTPUT" == "x0" ]];
           then
             diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed/*
             exit 1

--- a/.github/workflows/dependencies_matches.yaml
+++ b/.github/workflows/dependencies_matches.yaml
@@ -3,10 +3,6 @@ name: Check if dependencies match
 # at the same time, this check makes sure that we do use
 # the same version of said libraries.
 on: [push]
-permissions:
-  issues: write
-  pull-requests: write
-
 
 jobs:
   wownero-seed:
@@ -34,16 +30,16 @@ jobs:
           echo "WOWNERO_WOWNEROSEED=$(cat wownero/contrib/depends/packages/wownero_seed.mk | grep _download_file | tr '=.' '\n' | head -2 | tail -1)" >> $GITHUB_ENV
       - name: compare hashes
         run: |
-        if [[ "x$WOWNERO_WOWNEROSEED" == "x" ]];
-        then
-          echo "Unable to obtain wownero seed from wownero repo"
-          exit 1
-        fi
-        if [[ ! "x$EXTERNAL_WOWNEROSEED" == "x$WOWNERO_WOWNEROSEED" ]];
-        then
-          echo "external/wownero-seed doesn't match wownero/contrib/depends/packages/wownero_seed.mk checksum"
-          exit 1
-        fi
+          if [[ "x$WOWNERO_WOWNEROSEED" == "x" ]];
+          then
+            echo "Unable to obtain wownero seed from wownero repo"
+            exit 1
+          fi
+          if [[ ! "x$EXTERNAL_WOWNEROSEED" == "x$WOWNERO_WOWNEROSEED" ]];
+          then
+            echo "external/wownero-seed doesn't match wownero/contrib/depends/packages/wownero_seed.mk checksum"
+            exit 1
+          fi
   polyseed:
     strategy:
       matrix:

--- a/.github/workflows/dependencies_matches.yaml
+++ b/.github/workflows/dependencies_matches.yaml
@@ -66,7 +66,7 @@ jobs:
           popd
       - name: diff
         run: |
-          OUTPUT=$(diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed | grep -v .git | wc -l)
+          OUTPUT=$(diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed/* | grep -v .git | wc -l)
           if [[ ! "x$OUTPUT" == "x0" ]];
           then
             diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed/*

--- a/.github/workflows/dependencies_matches.yaml
+++ b/.github/workflows/dependencies_matches.yaml
@@ -1,0 +1,85 @@
+name: Check if dependencies match
+# Sometimes we have the libraries in two (or more) places 
+# at the same time, this check makes sure that we do use
+# the same version of said libraries.
+on: [push]
+permissions:
+  issues: write
+  pull-requests: write
+
+
+jobs:
+  wownero-seed:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:bookworm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Patch sources
+        run: |
+          git config --global --add safe.directory '*'
+          git config --global user.email "ci@mrcyjanek.net"
+          git config --global user.name "CI mrcyjanek.net"
+          ./apply_patches.sh monero
+          ./apply_patches.sh wownero
+      - name: obtain hashes
+        run: |
+          set -x
+          pushd external/wownero-seed
+            echo "EXTERNAL_WOWNEROSEED=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          popd
+          echo "WOWNERO_WOWNEROSEED=$(cat wownero/contrib/depends/packages/wownero_seed.mk | grep _download_file | tr '=.' '\n' | head -2 | tail -1)" >> $GITHUB_ENV
+      - name: compare hashes
+        run: |
+        if [[ "x$WOWNERO_WOWNEROSEED" == "x" ]];
+        then
+          echo "Unable to obtain wownero seed from wownero repo"
+          exit 1
+        fi
+        if [[ ! "x$EXTERNAL_WOWNEROSEED" == "x$WOWNERO_WOWNEROSEED" ]];
+        then
+          echo "external/wownero-seed doesn't match wownero/contrib/depends/packages/wownero_seed.mk checksum"
+          exit 1
+        fi
+  polyseed:
+    strategy:
+      matrix:
+        coin: [monero, wownero]
+    runs-on: ubuntu-latest
+    container:
+      image: debian:bookworm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Patch sources
+        run: |
+          git config --global --add safe.directory '*'
+          git config --global user.email "ci@mrcyjanek.net"
+          git config --global user.name "CI mrcyjanek.net"
+          ./apply_patches.sh ${{ matrix.coin }}
+      - name: prepare
+        run: |
+          set -x
+          pushd external/polyseed
+            echo "EXTERNAL_POLYSEED=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          popd
+          pushd ${{ matrix.coin }}/contrib/depends
+            make download # sorry, this is the easiest way
+            mkdir sources/polyseed
+            pushd sources/polyseed
+              tar xzf ../polyseed*.tar.gz
+            popd
+          popd
+      - name: diff
+        run: |
+          OUTPUT=$(diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed | grep -v .git)
+          if [[ ! "x$OUTPUT" == "x" ]];
+          then
+            diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed 
+            exit 1
+          fi

--- a/.github/workflows/dependencies_matches.yaml
+++ b/.github/workflows/dependencies_matches.yaml
@@ -72,6 +72,6 @@ jobs:
           OUTPUT=$(diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed | grep -v .git)
           if [[ ! "x$OUTPUT" == "x" ]];
           then
-            diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed 
+            diff -ra external/polyseed ${{ matrix.coin }}/contrib/depends/sources/polyseed/*
             exit 1
           fi

--- a/.github/workflows/dependencies_matches.yaml
+++ b/.github/workflows/dependencies_matches.yaml
@@ -7,8 +7,6 @@ on: [push]
 jobs:
   wownero-seed:
     runs-on: ubuntu-latest
-    container:
-      image: debian:bookworm
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,8 +43,6 @@ jobs:
       matrix:
         coin: [monero, wownero]
     runs-on: ubuntu-latest
-    container:
-      image: debian:bookworm
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Sometimes we have the libraries in two (or more) places at the same time, this check makes sure that we do use the same version of said libraries.