### PR TITLE
fix find wallets

### DIFF
--- a/impls/monero.dart/lib/monero.dart
+++ b/impls/monero.dart/lib/monero.dart
@@ -3595,7 +3595,9 @@ String WalletManager_findWallets(WalletManager wm_ptr, {required String path}) {
         .cast<Utf8>();
     final str = strPtr.toDartString();
     calloc.free(path_);
-    MONERO_free(strPtr.cast());
+    if (str.isNotEmpty) {
+      MONERO_free(strPtr.cast());
+    }
     debugEnd?.call('MONERO_WalletManager_findWallets');
     return str;
   } catch (e) {

--- a/impls/monero.dart/lib/monero.dart
+++ b/impls/monero.dart/lib/monero.dart
@@ -3585,7 +3585,8 @@ bool WalletManager_verifyWalletPassword(
   return s;
 }
 
-String WalletManager_findWallets(WalletManager wm_ptr, {required String path}) {
+List<String> WalletManager_findWallets(WalletManager wm_ptr,
+    {required String path}) {
   debugStart?.call('MONERO_WalletManager_findWallets');
   lib ??= MoneroC(DynamicLibrary.open(libPath));
   try {
@@ -3599,11 +3600,11 @@ String WalletManager_findWallets(WalletManager wm_ptr, {required String path}) {
       MONERO_free(strPtr.cast());
     }
     debugEnd?.call('MONERO_WalletManager_findWallets');
-    return str;
+    return str.split(";");
   } catch (e) {
     errorHandler?.call('MONERO_WalletManager_findWallets', e);
     debugEnd?.call('MONERO_WalletManager_findWallets');
-    return "";
+    return [];
   }
 }
 

--- a/impls/monero.dart/lib/wownero.dart
+++ b/impls/monero.dart/lib/wownero.dart
@@ -3230,7 +3230,9 @@ String WalletManager_findWallets(WalletManager wm_ptr, {required String path}) {
         .cast<Utf8>();
     final str = strPtr.toDartString();
     calloc.free(path_);
-    WOWNERO_free(strPtr.cast());
+    if (str.isNotEmpty) {
+      WOWNERO_free(strPtr.cast());
+    }
     debugEnd?.call('WOWNERO_WalletManager_findWallets');
     return str;
   } catch (e) {

--- a/impls/monero.dart/lib/wownero.dart
+++ b/impls/monero.dart/lib/wownero.dart
@@ -3220,7 +3220,8 @@ bool WalletManager_verifyWalletPassword(
   return s;
 }
 
-String WalletManager_findWallets(WalletManager wm_ptr, {required String path}) {
+List<String> WalletManager_findWallets(WalletManager wm_ptr,
+    {required String path}) {
   debugStart?.call('WOWNERO_WalletManager_findWallets');
   lib ??= WowneroC(DynamicLibrary.open(libPath));
   try {
@@ -3234,11 +3235,11 @@ String WalletManager_findWallets(WalletManager wm_ptr, {required String path}) {
       WOWNERO_free(strPtr.cast());
     }
     debugEnd?.call('WOWNERO_WalletManager_findWallets');
-    return str;
+    return str.split(";");
   } catch (e) {
     errorHandler?.call('WOWNERO_WalletManager_findWallets', e);
     debugEnd?.call('WOWNERO_WalletManager_findWallets');
-    return "";
+    return [];
   }
 }
 
@@ -3607,7 +3608,6 @@ int WOWNERO_deprecated_14WordSeedHeight({
   debugEnd?.call('WOWNERO_deprecated_14WordSeedHeight');
   return s;
 }
-
 
 String WOWNERO_checksum_wallet2_api_c_h() {
   debugStart?.call('WOWNERO_checksum_wallet2_api_c_h');


### PR DESCRIPTION
- prevent crash when there are no wallets found
- return `List<String>` instead of colon separated `String`