### PR TITLE
fix: allocation to stack instead of heap in cn_slow_hash causing

### DIFF
--- a/contrib/depends/toolchain.cmake.in
+++ b/contrib/depends/toolchain.cmake.in
@@ -199,5 +199,9 @@ include_directories(@prefix@/include/wownero_seed)
 add_definitions(-DPOLYSEED_STATIC=ON)
 add_definitions(-DMOBILE_WALLET_BUILD)
 
+if (ANDROID OR IOS)
+  add_definitions(-DFORCE_USE_HEAP=1)
+endif()
+
 #Create a new global cmake flag that indicates building with depends
 set (DEPENDS true)


### PR DESCRIPTION
older low end devices to crash