### PR TITLE
Rust bootstrap support for macOS aarch64

### DIFF
--- a/contrib/depends/hosts/darwin.mk
+++ b/contrib/depends/hosts/darwin.mk
@@ -1,4 +1,4 @@
-OSX_MIN_VERSION=10.14
+OSX_MIN_VERSION=10.15
 LD64_VERSION=609
 ifeq (aarch64, $(host_arch))
 CC_target=arm64-apple-$(host_os)
@@ -14,10 +14,10 @@ darwin_CFLAGS=-pipe
 darwin_CXXFLAGS=$(darwin_CFLAGS)
 darwin_ARFLAGS=cr
 
-darwin_release_CFLAGS=-O1
+darwin_release_CFLAGS=-O3
 darwin_release_CXXFLAGS=$(darwin_release_CFLAGS)
 
-darwin_debug_CFLAGS=-O1
+darwin_debug_CFLAGS=-O3
 darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 
 darwin_native_toolchain=native_cctools darwin_sdk

--- a/contrib/depends/packages/native_mrustc.mk
+++ b/contrib/depends/packages/native_mrustc.mk
@@ -5,9 +5,11 @@ $(package)_download_file=06b87d1af49d2db3bd850fdee8888055dd540dd1.tar.gz
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=d3d3b84a100e71628afecf1125dbaa9bfc54ef9578c4fd81d75dca34c96f2565
 $(package)_dependencies=native_ccache
+$(package)_patches=codegen_c.cpp.patch
 
 define $(package)_preprocess_cmds
   cd $($(package)_extract_dir) && \
+  patch -p1 < $($(package)_patch_dir)/codegen_c.cpp.patch && \
   if [ -f script-overrides/stable-1.54.0-macos/build_std.txt ]; then \
     ARCH=`uname -m | sed 's/arm64/aarch64/'` && \
     sed -i.bak "s/STD_ENV_ARCH=[a-zA-Z0-9_]*/STD_ENV_ARCH=$$$$ARCH/" script-overrides/stable-1.54.0-macos/build_std.txt; \
@@ -16,12 +18,8 @@ define $(package)_preprocess_cmds
     ARCH=`uname -m | sed 's/arm64/aarch64/'` && \
     sed -i.bak "s/STD_ENV_ARCH=[a-zA-Z0-9_]*/STD_ENV_ARCH=$$$$ARCH/" script-overrides/stable-1.54.0-linux/build_std.txt; \
   fi && \
-  if [ `uname -s` = "Darwin" ]; then \
-    echo 'Patching mrustc to work with clang on macOS' && \
-    sed -i.bak 's/-fno-tree-sra//g' Makefile && \
-    grep -rl -- "-fno-tree-sra" . | xargs sed -i.bak 's/-fno-tree-sra//g'; \
-  fi && \
   sed -i.bak 's/^make$$$$/make $$$$@/' build-1.54.0.sh &&\
+  sed -i '' 's/^[[:space:]]*RUSTC_TARGET ?= x86_64-apple-darwin/RUSTC_TARGET ?= aarch64-apple-darwin/' run_rustc/Makefile && \
   echo >> build-1.54.0.sh && \
   echo make -C run_rustc >> build-1.54.0.sh
 endef
@@ -31,9 +29,14 @@ define $(package)_build_cmds
   $($(package)_build_env) PARLEVEL=$(shell nproc) ./build-1.54.0.sh -j$(shell nproc)
 endef
 
+# FIXME bad dylib paths embedded in the rustc binary, forcing install_name_tool dark magic
 define $(package)_stage_cmds
     mkdir -p $($(package)_staging_prefix_dir)/native/rust_1_54_0/bin && \
-    cp -a run_rustc/output-1.54.0/prefix-2/bin/rustc $($(package)_staging_prefix_dir)/native/rust_1_54_0/bin && \
-    cp -a run_rustc/output-1.54.0/prefix/bin/cargo $($(package)_staging_prefix_dir)/native/rust_1_54_0/bin && \
-    cp -a run_rustc/output-1.54.0/prefix-2/lib $($(package)_staging_prefix_dir)/native/rust_1_54_0/lib
+    cp -a run_rustc/output-1.54.0/prefix/bin/ $($(package)_staging_prefix_dir)/native/rust_1_54_0/bin && \
+    cp -a run_rustc/output-1.54.0/prefix/lib $($(package)_staging_prefix_dir)/native/rust_1_54_0/lib && \
+    if [ `uname -s` = "Darwin" ]; then \
+    install_name_tool -change $($(package)_extract_dir)/run_rustc/output-1.54.0/build-rustc/aarch64-apple-darwin/release/deps/librustc_driver.dylib @loader_path/../lib/rustlib/aarch64-apple-darwin/lib/librustc_driver.dylib $($(package)_staging_prefix_dir)/native/rust_1_54_0/bin/rustc_binary && \
+    install_name_tool -change $($(package)_extract_dir)/run_rustc/output-1.54.0/build-std2/aarch64-apple-darwin/release/deps/libstd.dylib @loader_path/../lib/rustlib/aarch64-apple-darwin/lib/libstd.dylib $($(package)_staging_prefix_dir)/native/rust_1_54_0/bin/rustc_binary && \
+    install_name_tool -change $($(package)_extract_dir)/run_rustc/output-1.54.0/build-std2/aarch64-apple-darwin/release/deps/libstd.dylib @loader_path/libstd.dylib $($(package)_staging_prefix_dir)/native/rust_1_54_0/lib/rustlib/aarch64-apple-darwin/lib/librustc_driver.dylib; \
+    fi
 endef

--- a/contrib/depends/packages/native_rust_1_55_0.mk
+++ b/contrib/depends/packages/native_rust_1_55_0.mk
@@ -5,9 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=b2379ac710f5f876ee3c3e03122fe33098d6765d371cac6c31b1b6fc8e43821e
 $(package)_dependencies=native_mrustc
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
-    sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
     echo 'vendor = true' >> config.toml && \
@@ -20,7 +22,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 --verbose -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_56_1.mk
+++ b/contrib/depends/packages/native_rust_1_56_1.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=c3898dfaadaa193dc88ddbc5345946a163211b58621df1cfff70186b4fc79511
 $(package)_dependencies=native_rust_1_55_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_57_0.mk
+++ b/contrib/depends/packages/native_rust_1_57_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=3546f9c3b91b1f8b8efd26c94d6b50312c08210397b4072ed2748e2bd4445c1a
 $(package)_dependencies=native_rust_1_56_1
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_58_1.mk
+++ b/contrib/depends/packages/native_rust_1_58_1.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=a839afdd3625d6f3f3c4c10b79813675d1775c460d14be1feaf33a6c829c07c7
 $(package)_dependencies=native_rust_1_57_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_59_0.mk
+++ b/contrib/depends/packages/native_rust_1_59_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=a7c8eeaee85bfcef84c96b02b3171d1e6540d15179ff83dddd9eafba185f85f9
 $(package)_dependencies=native_rust_1_58_1
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_60_0.mk
+++ b/contrib/depends/packages/native_rust_1_60_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=20ca826d1cf674daf8e22c4f8c4b9743af07973211c839b85839742314c838b7
 $(package)_dependencies=native_rust_1_59_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_61_0.mk
+++ b/contrib/depends/packages/native_rust_1_61_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=ad0b4351675aa9abdf4c7e066613bd274c4391c5506db152983426376101daed
 $(package)_dependencies=native_rust_1_60_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_62_1.mk
+++ b/contrib/depends/packages/native_rust_1_62_1.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=72acbe6ffcd94f598382a7430b0d85ee8f679e6d0b27f3f566ed1c16c978133f
 $(package)_dependencies=native_rust_1_61_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_63_0.mk
+++ b/contrib/depends/packages/native_rust_1_63_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=1f9580295642ef5da7e475a8da2397d65153d3f2cb92849dbd08ed0effca99d0
 $(package)_dependencies=native_rust_1_62_1
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_64_0.mk
+++ b/contrib/depends/packages/native_rust_1_64_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=b3cd9f481e1a2901bf6f3808d30c69cc4ea80d93c4cc4e2ed52258b180381205
 $(package)_dependencies=native_rust_1_63_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_65_0.mk
+++ b/contrib/depends/packages/native_rust_1_65_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=5828bb67f677eabf8c384020582b0ce7af884e1c84389484f7f8d00dd82c0038
 $(package)_dependencies=native_rust_1_64_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_66_1.mk
+++ b/contrib/depends/packages/native_rust_1_66_1.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=5b3c933a94c72187705d4ee293198babfdd09442f5937fbd685db3a81f4959ba
 $(package)_dependencies=native_rust_1_65_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_67_1.mk
+++ b/contrib/depends/packages/native_rust_1_67_1.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=46483d3e5de85a3bd46f8e7a3ae1837496391067dbe713a25d3cf051b3d9ff6e
 $(package)_dependencies=native_rust_1_66_1
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_68_2.mk
+++ b/contrib/depends/packages/native_rust_1_68_2.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=93339c23f7cd4d0c45db58e18b4c6e16d6070f4277aad9d2492d23294bf32e96
 $(package)_dependencies=native_rust_1_67_1
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_69_0.mk
+++ b/contrib/depends/packages/native_rust_1_69_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=fb05971867ad6ccabbd3720279f5a94b99f61024923187b56bb5c455fa3cf60f
 $(package)_dependencies=native_rust_1_68_2
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_70_0.mk
+++ b/contrib/depends/packages/native_rust_1_70_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=b2bfae000b7a5040e4ec4bbc50a09f21548190cb7570b0ed77358368413bd27c
 $(package)_dependencies=native_rust_1_69_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_71_1.mk
+++ b/contrib/depends/packages/native_rust_1_71_1.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=6fa90d50d1d529a75f6cc349784de57d7ec0ba2419b09bde7d335c25bd4e472e
 $(package)_dependencies=native_rust_1_70_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_72_1.mk
+++ b/contrib/depends/packages/native_rust_1_72_1.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=7f48845f6a52cdbb5d63fb0528fd5f520eb443275b55f98e328159f86568f895
 $(package)_dependencies=native_rust_1_71_1
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_73_0.mk
+++ b/contrib/depends/packages/native_rust_1_73_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=96d62e6d1f2d21df7ac8acb3b9882411f9e7c7036173f7f2ede9e1f1f6b1bb3a
 $(package)_dependencies=native_rust_1_72_1
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_74_1.mk
+++ b/contrib/depends/packages/native_rust_1_74_1.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=67db3e22fc9921c885baae5953ba144fc474cde29ec69ab56d43ce764206231d
 $(package)_dependencies=native_rust_1_73_0
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_75_0.mk
+++ b/contrib/depends/packages/native_rust_1_75_0.mk
@@ -5,8 +5,11 @@ $(package)_file_name=rustc-$($(package)_version)-src.tar.gz
 $(package)_download_file=$($(package)_file_name)
 $(package)_sha256_hash=5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088
 $(package)_dependencies=native_rust_1_74_1
+$(package)_patches=assembly.h.patch
 
 define $(package)_preprocess_cmds
+    cd $($(package)_extract_dir) && \
+    patch -p1 < $($(package)_patch_dir)/assembly.h.patch && \
     sed -i '18i#include <cstdint>' src/llvm-project/llvm/include/llvm/Support/Signals.h || true && \
     echo '[build]' > config.toml && \
     echo 'full-bootstrap = true' >> config.toml && \
@@ -20,7 +23,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_76_0.mk
+++ b/contrib/depends/packages/native_rust_1_76_0.mk
@@ -20,7 +20,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_77_1.mk
+++ b/contrib/depends/packages/native_rust_1_77_1.mk
@@ -20,7 +20,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_78_0.mk
+++ b/contrib/depends/packages/native_rust_1_78_0.mk
@@ -12,15 +12,15 @@ define $(package)_preprocess_cmds
     echo 'full-bootstrap = true' >> config.toml && \
     echo 'vendor = true' >> config.toml && \
     echo 'extended = true' >> config.toml && \
-    echo 'rustc = "$(host_prefix)/native/rust_1_77_0/bin/rustc"' >> config.toml && \
-    echo 'cargo = "$(host_prefix)/native/rust_1_77_0/bin/cargo"' >> config.toml && \
+    echo 'rustc = "$(host_prefix)/native/rust_1_77_1/bin/rustc"' >> config.toml && \
+    echo 'cargo = "$(host_prefix)/native/rust_1_77_1/bin/cargo"' >> config.toml && \
     echo '[llvm]' >> config.toml && \
     echo 'ninja = false' >> config.toml && \
     echo 'download-ci-llvm = false' >> config.toml
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_79_0.mk
+++ b/contrib/depends/packages/native_rust_1_79_0.mk
@@ -20,7 +20,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_80_1.mk
+++ b/contrib/depends/packages/native_rust_1_80_1.mk
@@ -20,7 +20,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_81_0.mk
+++ b/contrib/depends/packages/native_rust_1_81_0.mk
@@ -20,7 +20,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/packages/native_rust_1_82_0.mk
+++ b/contrib/depends/packages/native_rust_1_82_0.mk
@@ -20,7 +20,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_build_cmds
-    python3 ./x.py build --stage 3
+    python3 ./x.py build --stage 3 -j $(NUM_PROC)
 endef
 
 define $(package)_stage_cmds

--- a/contrib/depends/patches/native_mrustc/codegen_c.cpp.patch
+++ b/contrib/depends/patches/native_mrustc/codegen_c.cpp.patch
@@ -1,0 +1,17 @@
+--- a/src/trans/codegen_c.cpp   2025-07-08 00:17:10.022769383 +0200
++++ b/src/trans/codegen_c.cpp   2025-07-08 00:17:18.404645999 +0200
+@@ -1297,8 +1297,14 @@
+                 // HACK: Work around [https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117423] by disabling an optimisation stage
+                 if( opt.opt_level > 0 )
+                 {
++                    #ifndef __clang__ // clang doesn't have this option.
+                     args.push_back("-fno-tree-sra");
++                    #endif
+                 }
++                #ifdef __APPLE__
++                args.push_back("-framework");
++                args.push_back("Security");
++                #endif
+                 if( opt.emit_debug_info )
+                 {
+                     args.push_back("-g");

--- a/contrib/depends/patches/native_rust_1_55_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_55_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2021-07-12 08:53:30.000000000 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-08 21:51:23.202034452 +0200
+@@ -249,9 +249,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY(name) SEPARATOR                                    \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_56_1/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_56_1/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.469384349 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:03.694440678 +0200
+@@ -254,9 +254,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_57_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_57_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.469384349 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:03.694440678 +0200
+@@ -254,9 +254,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_58_1/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_58_1/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.469384349 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:03.694440678 +0200
+@@ -254,9 +254,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_59_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_59_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.469384349 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:03.694440678 +0200
+@@ -254,9 +254,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_60_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_60_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_61_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_61_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_62_1/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_62_1/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_63_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_63_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_64_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_64_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_65_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_65_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_66_1/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_66_1/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_67_1/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_67_1/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_68_2/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_68_2/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_69_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_69_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_70_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_70_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_71_1/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_71_1/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_72_1/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_72_1/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.474103047 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:14.327250160 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_73_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_73_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.479066578 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:21.978710547 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_74_1/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_74_1/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.479066578 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:21.978710547 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \

--- a/contrib/depends/patches/native_rust_1_75_0/assembly.h.patch
+++ b/contrib/depends/patches/native_rust_1_75_0/assembly.h.patch
@@ -1,0 +1,14 @@
+--- a/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:41:44.479066578 +0200
++++ b/src/llvm-project/compiler-rt/lib/builtins/assembly.h	2025-07-10 12:46:21.978710547 +0200
+@@ -260,9 +260,10 @@
+   .globl name SEPARATOR                                                        \
+   SYMBOL_IS_FUNC(name) SEPARATOR                                               \
+   DECLARE_SYMBOL_VISIBILITY_UNMANGLED(name) SEPARATOR                          \
++  name: SEPARATOR                                                              \
+   CFI_START SEPARATOR                                                          \
+   DECLARE_FUNC_ENCODING                                                        \
+-  name: SEPARATOR BTI_C
++  BTI_C
+ 
+ #define DEFINE_COMPILERRT_FUNCTION_ALIAS(name, target)                         \
+   .globl SYMBOL_NAME(name) SEPARATOR                                           \


### PR DESCRIPTION
Full support for bootstrapping Rust 1.82.0 with mrustc (starting from 1.54.0) on macOS ARM64.