### PR TITLE
Fix copy-paste bugs in cw_WalletListener wrapper functions

### DIFF
--- a/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.cpp
+++ b/monero_libwallet2_api_c/src/main/cpp/monero_wallet2_api_c.cpp
@@ -2638,21 +2638,21 @@ bool MONERO_cw_WalletListener_isNeedToRefresh(void* cw_walletListener_ptr) {
 bool MONERO_cw_WalletListener_isNewTransactionExist(void* cw_walletListener_ptr) {
     DEBUG_START()
     MONERO_cw_WalletListener *listener = reinterpret_cast<MONERO_cw_WalletListener*>(cw_walletListener_ptr);
-    return listener->cw_isNeedToRefresh();
+    return listener->cw_isNewTransactionExist();
     DEBUG_END()
 };
 
 void MONERO_cw_WalletListener_resetIsNewTransactionExist(void* cw_walletListener_ptr) {
     DEBUG_START()
     MONERO_cw_WalletListener *listener = reinterpret_cast<MONERO_cw_WalletListener*>(cw_walletListener_ptr);
-    listener->cw_isNeedToRefresh();
+    listener->cw_resetIsNewTransactionExist();
     DEBUG_END()
 };
 
 uint64_t MONERO_cw_WalletListener_height(void* cw_walletListener_ptr) {
     DEBUG_START()
     MONERO_cw_WalletListener *listener = reinterpret_cast<MONERO_cw_WalletListener*>(cw_walletListener_ptr);
-    return listener->cw_isNeedToRefresh();
+    return listener->cw_height();
     DEBUG_END()
 };
 

--- a/wownero_libwallet2_api_c/src/main/cpp/wownero_wallet2_api_c.cpp
+++ b/wownero_libwallet2_api_c/src/main/cpp/wownero_wallet2_api_c.cpp
@@ -2381,21 +2381,21 @@ bool WOWNERO_cw_WalletListener_isNeedToRefresh(void* cw_walletListener_ptr) {
 bool WOWNERO_cw_WalletListener_isNewTransactionExist(void* cw_walletListener_ptr) {
     DEBUG_START()
     WOWNERO_cw_WalletListener *listener = reinterpret_cast<WOWNERO_cw_WalletListener*>(cw_walletListener_ptr);
-    return listener->cw_isNeedToRefresh();
+    return listener->cw_isNewTransactionExist();
     DEBUG_END()
 };
 
 void WOWNERO_cw_WalletListener_resetIsNewTransactionExist(void* cw_walletListener_ptr) {
     DEBUG_START()
     WOWNERO_cw_WalletListener *listener = reinterpret_cast<WOWNERO_cw_WalletListener*>(cw_walletListener_ptr);
-    listener->cw_isNeedToRefresh();
+    listener->cw_resetIsNewTransactionExist();
     DEBUG_END()
 };
 
 uint64_t WOWNERO_cw_WalletListener_height(void* cw_walletListener_ptr) {
     DEBUG_START()
     WOWNERO_cw_WalletListener *listener = reinterpret_cast<WOWNERO_cw_WalletListener*>(cw_walletListener_ptr);
-    return listener->cw_isNeedToRefresh();
+    return listener->cw_height();
     DEBUG_END()
 };
 


### PR DESCRIPTION
## Summary

Three C wrapper functions in `monero_wallet2_api_c.cpp` call the wrong underlying method on `MONERO_cw_WalletListener`. All three incorrectly call `cw_isNeedToRefresh()` instead of their intended methods.

## Changes

| Function | Was calling | Now calls |
|----------|-----------|-----------|
| `MONERO_cw_WalletListener_isNewTransactionExist` | `cw_isNeedToRefresh()` | `cw_isNewTransactionExist()` |
| `MONERO_cw_WalletListener_resetIsNewTransactionExist` | `cw_isNeedToRefresh()` (read-only) | `cw_resetIsNewTransactionExist()` |
| `MONERO_cw_WalletListener_height` | `cw_isNeedToRefresh()` (returns bool as uint64) | `cw_height()` |

If the same bugs exist in the Wownero copy, they are fixed there too.

## Impact

- `isNewTransactionExist` was returning the refresh flag instead of the new-transaction flag
- `resetIsNewTransactionExist` was a no-op (calling a read-only getter instead of resetting `m_new_transaction`)
- `height` was returning 0 or 1 instead of the actual block height

These bugs contribute to stale transaction confirmation counts in downstream wallets (e.g. Cake Wallet — see cake-tech/cake_wallet#3110).

Fixes #182